### PR TITLE
Rename resources and providers to match cookbook name.

### DIFF
--- a/libraries/matchers.rb
+++ b/libraries/matchers.rb
@@ -26,8 +26,8 @@ if defined?(ChefSpec)
     ChefSpec::Matchers::ResourceMatcher.new(:graphite_storage, :delete, name)
   end
 
-  def create_graphite_carbon_conf_accumulator(name)
-    ChefSpec::Matchers::ResourceMatcher.new(:graphite_carbon_conf_accumulator, :create, name)
+  def create_socrata_graphite_fork_carbon_conf_accumulator(name)
+    ChefSpec::Matchers::ResourceMatcher.new(:socrata_graphite_fork_carbon_conf_accumulator, :create, name)
   end
 
   def enable_runit_service(resource_name)

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'sysadmin@socrata.com'
 license          'Apache 2.0'
 description      'Installs/Configures graphite'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '999.0.2'
+version          '999.0.3'
 
 supports 'ubuntu'
 supports 'debian'

--- a/providers/service_runit.rb
+++ b/providers/service_runit.rb
@@ -41,7 +41,7 @@ end
 
 def manage_runit_service(resource_action)
   runit_service(new_resource.service_name) do
-    cookbook "graphite"
+    cookbook "socrata-graphite-fork"
     run_template_name "carbon"
     default_logger true
     finish_script_template_name "carbon"

--- a/recipes/_carbon_config.rb
+++ b/recipes/_carbon_config.rb
@@ -25,7 +25,7 @@ file "carbon.conf" do
   action :nothing
 end
 
-graphite_carbon_conf_accumulator "default"
+socrata_graphite_fork_carbon_conf_accumulator "default"
 
 file "storage-schemas.conf" do
   path "#{node['graphite']['base_dir']}/conf/storage-schemas.conf"
@@ -35,4 +35,4 @@ file "storage-schemas.conf" do
   action :nothing
 end
 
-graphite_storage_conf_accumulator "default"
+socrata_graphite_fork_storage_conf_accumulator "default"

--- a/resources/service.rb
+++ b/resources/service.rb
@@ -24,7 +24,7 @@ attribute :name, kind_of: String, default: nil, name_attribute: true
 
 def initialize(*args)
   super
-  @provider = Chef::Provider::GraphiteServiceRunit
+  @provider = Chef::Provider::SocrataGraphiteForkServiceRunit
 end
 
 def service_name

--- a/spec/providers/service_runit_spec.rb
+++ b/spec/providers/service_runit_spec.rb
@@ -2,14 +2,14 @@ require "spec_helper"
 load_provider("graphite", "service_runit")
 load_resource("graphite", "service")
 
-describe Chef::Provider::GraphiteServiceRunit do
+describe Chef::Provider::SocrataGraphiteForkServiceRunit do
 
   before do
     using_libraries("runit")
     node.set[:runit] = Mash.new
   end
 
-  let(:resource_class) { Chef::Resource::GraphiteService }
+  let(:resource_class) { Chef::Resource::SocrataGraphiteForkService }
   let(:resource_name) { "yabbadoo" }
 
   it "is whyrun support" do

--- a/spec/recipes/_carbon_config_spec.rb
+++ b/spec/recipes/_carbon_config_spec.rb
@@ -28,8 +28,8 @@ describe 'socrata-graphite-fork::_carbon_config' do
 
   end
 
-  it "to create the graphite_carbon_conf_accumulator resource" do
-    expect(chef_run).to create_graphite_carbon_conf_accumulator("default")
+  it "to create the socrata_graphite_fork_carbon_conf_accumulator resource" do
+    expect(chef_run).to create_socrata_graphite_fork_carbon_conf_accumulator("default")
   end
 
 end

--- a/spec/resources/service_spec.rb
+++ b/spec/resources/service_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 load_resource("graphite", "service")
 load_provider("graphite", "service_runit")
 
-describe Chef::Resource::GraphiteService do
+describe Chef::Resource::SocrataGraphiteForkService do
 
   let(:resource_name) { "mega:beta" }
 
@@ -27,7 +27,7 @@ describe Chef::Resource::GraphiteService do
   end
 
   it "provider defaults the runit service" do
-    expect(resource.provider).to eq(Chef::Provider::GraphiteServiceRunit)
+    expect(resource.provider).to eq(Chef::Provider::SocrataGraphiteForkServiceRunit)
   end
 
   describe "#service_name" do


### PR DESCRIPTION
This probably isn't complete and is a kind of evil horrible hack to make stuff work,
it is a bit annoying how cookbook names propogate into class names without real namespacing.