### PR TITLE
I missed a storage schema rename missed during cookbook renaming.

### DIFF
--- a/libraries/provider_storage_conf_accumulator.rb
+++ b/libraries/provider_storage_conf_accumulator.rb
@@ -36,7 +36,7 @@ class Chef
       end
 
       def action_create
-        resources = run_context.resource_collection.select { |x| x.resource_name == :graphite_storage_schema }
+        resources = run_context.resource_collection.select { |x| x.resource_name == :socrata_graphite_fork_storage_schema }
         file_resource = run_context.resource_collection.find(new_resource.file_resource)
 
         contents = "# This file is managed by Chef, your changes *will* be overwritten!\n\n"

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'sysadmin@socrata.com'
 license          'Apache 2.0'
 description      'Installs/Configures graphite'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '999.0.4'
+version          '999.0.5'
 
 supports 'ubuntu'
 supports 'debian'


### PR DESCRIPTION
Did I mention I hate how the cookbook name creeps everywhere like this?