### PR TITLE
Drop the graphite-web '--plugins carbon' switch

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'sysadmin@socrata.com'
 license          'Apache 2.0'
 description      'Installs/Configures graphite'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '999.1.0'
+version          '999.1.1'
 
 supports 'ubuntu'
 supports 'debian'

--- a/recipes/uwsgi.rb
+++ b/recipes/uwsgi.rb
@@ -18,7 +18,7 @@
 #
 
 command = "#{node['graphite']['base_dir']}/bin/uwsgi --processes #{node['graphite']['uwsgi']['workers']}"
-command << " --plugins carbon --carbon #{node['graphite']['uwsgi']['carbon']}" if node['graphite']['uwsgi']['carbon']
+command << " --carbon #{node['graphite']['uwsgi']['carbon']}" if node['graphite']['uwsgi']['carbon']
 command << " --http :#{node['graphite']['uwsgi']['port']}" if node['graphite']['uwsgi']['listen_http']
 command << " --pythonpath #{node['graphite']['base_dir']}/lib \
 --pythonpath #{node['graphite']['base_dir']}/webapp/graphite \


### PR DESCRIPTION
## Description

Modern versions of uWSGI have the Carbon plugin built in and load it
automatically. Trying to load it explicitly results in this red herring error
message:

```
Jul 19 19:18:16 ip-10-110-32-208 uwsgi[10831]: open("./carbon_plugin.so"): No such file or directory [core/utils.c line 3724]
Jul 19 19:18:16 ip-10-110-32-208 uwsgi[10831]: !!! UNABLE to load uWSGI plugin: ./carbon_plugin.so: cannot open shared object file: No such file or directory !!!
```

uWSGI then ships its metrics to Carbon regardless of the switch being there or
not.

### Issues Resolved

Strange, meaningless errors in the graphite-web log.
