### PR TITLE
Put guards around Python packages that'll otherwise reinstall on every run

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'sysadmin@socrata.com'
 license          'Apache 2.0'
 description      'Installs/Configures graphite'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '999.1.1'
+version          '999.1.2'
 
 supports 'ubuntu'
 supports 'debian'

--- a/recipes/_carbon_packages.rb
+++ b/recipes/_carbon_packages.rb
@@ -47,4 +47,10 @@ python_package 'carbon' do
   group node['graphite']['group']
   install_options '--no-binary=:all:'
   virtualenv node['graphite']['base_dir']
+  not_if do
+    sh = shell_out!("#{node['graphite']['base_dir']}/bin/pip list --format json",
+                    env: { PYTHONPATH: "#{node['graphite']['base_dir']}/lib" })
+    json = JSON.parse(sh.stdout)
+    json.find { |i| i['name'] == 'carbon' && i['version'] == node['graphite']['version'] }
+  end
 end

--- a/recipes/_web_packages.rb
+++ b/recipes/_web_packages.rb
@@ -34,11 +34,11 @@ end
 python_package 'uwsgi' do
   user node['graphite']['user']
   group node['graphite']['group']
-  options '--isolated'
+  install_options '--isolated'
   virtualenv node['graphite']['base_dir']
 end
 
-python_package 'graphite_web' do
+python_package 'graphite-web' do
   package_name lazy {
     key = node['graphite']['install_type']
     node['graphite']['package_names']['graphite_web'][key]
@@ -50,4 +50,10 @@ python_package 'graphite_web' do
   group node['graphite']['group']
   install_options '--no-binary=:all:'
   virtualenv node['graphite']['base_dir']
+  not_if do
+    sh = shell_out!("#{node['graphite']['base_dir']}/bin/pip list --format json",
+                    env: { PYTHONPATH: "#{node['graphite']['base_dir']}/webapp" })
+    json = JSON.parse(sh.stdout)
+    json.find { |i| i['name'] == 'graphite-web' && i['version'] == node['graphite']['version'] }
+  end
 end


### PR DESCRIPTION
## Description

Graphite's packages install themselves in funky paths that don't show up in pip,
so poise-python thinks it needs to install them every time. Further, there's no
way to set environment variables for a `python_package` resource.

With these changes applied, uwsgi; carbon; and graphite-web no longer get
reinstalled on every Chef run.

### Issues Resolved

Chef reinstalls uwsgi, carbon, and graphite-web every time.

### Check List
- [x] All tests pass. See https://github.com/sous-chefs/apache2/blob/master/TESTING.md
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable