### PR TITLE
Thanks `pip`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,14 @@
 
 This file is used to list changes made in each version of the graphite cookbook.
 
+## 999.0.3
 
-## 1.0.6 
+- Migrate to `snu_python` over `poise-python`
+- Install `Graphite@1.1.6`
+- Install python package `pyuwsgi` instead of `uwsgi` due to build errors from
+  the new pip release
+
+## 1.0.6
 
 - Syntax and styling updates
 - Compatibility with Chef 13 (.[@oscar123mendoza])

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-default['graphite']['version'] = '1.1.3'
+default['graphite']['version'] = '1.1.6'
 # You may set versions of Twisted and Django packages explicitly, otherwise it
 # installs actual versions of these packages as dependecies
 default['graphite']['twisted_version'] = ''

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'sysadmin@socrata.com'
 license          'Apache 2.0'
 description      'Installs/Configures graphite'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '999.1.2'
+version          '999.1.3'
 
 supports 'ubuntu'
 supports 'debian'
@@ -13,7 +13,7 @@ supports 'centos'
 supports 'scientific'
 supports 'oracle'
 
-depends  'poise-python', '>= 1.5'
+depends  'snu_python', '>= 0.2.0'
 
 source_url 'https://github.com/socrata-cookbooks/socrata-graphite-fork'
 issues_url 'https://github.com/socrata-cookbooks/socrata-graphite-fork/issues'

--- a/recipes/_web_packages.rb
+++ b/recipes/_web_packages.rb
@@ -31,7 +31,7 @@ python_package 'django' do
   end
 end
 
-python_package 'uwsgi' do
+python_package 'pyuwsgi' do
   user node['graphite']['user']
   group node['graphite']['group']
   install_options '--isolated'

--- a/test/fixtures/cookbooks/test/metadata.rb
+++ b/test/fixtures/cookbooks/test/metadata.rb
@@ -1,4 +1,4 @@
 name 'test'
 version '0.1.0'
 
-depends 'graphite'
+depends 'socrata-graphite-fork'


### PR DESCRIPTION
## Description

The pip team released 20.0.2 which brought some breaking changes.

### Issues Resolved

- `snu_python` is now being used over `poise-python` since it has the pip
fixes.
- `uwsgi` fails to build due to `gcc7+`.  `pyuwsgi` appears to build
appropriately and looks to be interchangeable.
- Upgrade `graphite` to latest `@v1.1.6`

### Check List
- [ ] All tests pass. See https://github.com/sous-chefs/apache2/blob/master/TESTING.md
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
