### PR TITLE
Give Graphite a Home Dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 This file is used to list changes made in each version of the graphite cookbook.
 
-## 999.0.3
+## 999.1.4
+
+- Ensure graphite user has a home dir at `/var/lib/graphite`
+
+## 999.1.3
 
 - Migrate to `snu_python` over `poise-python`
 - Install `Graphite@1.1.6`

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'sysadmin@socrata.com'
 license          'Apache 2.0'
 description      'Installs/Configures graphite'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '999.1.3'
+version          '999.1.4'
 
 supports 'ubuntu'
 supports 'debian'

--- a/recipes/_user.rb
+++ b/recipes/_user.rb
@@ -30,3 +30,10 @@ user node['graphite']['user'] do
   manage_home true
   action :create
 end
+
+directory '/var/lib/graphite' do
+  owner node['graphite']['user']
+  group node['graphite']['group']
+  mode '0755'
+  action :create
+end


### PR DESCRIPTION
## Description

It appears the wheel cache is sad because the `graphite` user lacked a
home dir.

### Issues Resolved

Pip should be able to install things correctly for the `graphite` user now that a home dir exists.

### Check List
- [x] All tests pass. See https://github.com/sous-chefs/apache2/blob/master/TESTING.md
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
